### PR TITLE
Clean up task structure

### DIFF
--- a/include/codec/util.hpp
+++ b/include/codec/util.hpp
@@ -381,14 +381,18 @@ Either<std::string, std::vector<std::string>> getSafeDecodedMessage(
         std::memcpy(decode_buffer, raw_buffer + 5, message_byte_size);
         const IGData::IGTask *ig_task = GetIGTask(&decode_buffer);
 
+        /**
+         * /note The specification for the order of these arguments can be found
+         * in namespace: Task::IGTaskIndex
+         */
         return right(std::move(
           std::vector<std::string>{
+            std::to_string(ig_task->mask()), // Mask always comes first
             ig_task->file_info()->str(), ig_task->time()->str(),
             ig_task->description()->str(), ig_task->hashtags()->str(),
             ig_task->requested_by()->str(), ig_task->requested_by_phrase()->str(),
             ig_task->promote_share()->str(), ig_task->link_bio()->str(),
             std::to_string(ig_task->is_video()),
-            std::to_string(ig_task->mask()),
             ig_task->header()->str(), ig_task->user()->str()
           }
         ));

--- a/include/executor/task_handlers/instagram.hpp
+++ b/include/executor/task_handlers/instagram.hpp
@@ -2,11 +2,31 @@
 #define __INSTAGRAM_HPP__
 
 #include <codec/util.hpp>
+#include <executor/task_handlers/task.hpp>
 #include <executor/scheduler.hpp>
 #include <iostream>
 #include <vector>
 
 namespace Task {
+  /**
+   * IGTaskIndex
+   *
+   * These indices describe the order of arguments expected for processing of an IGTask
+   */
+  namespace IGTaskIndex {
+    static constexpr uint8_t MASK = Task::TaskIndexes::MASK;
+    static constexpr uint8_t FILEINFO = 1;
+    static constexpr uint8_t DATETIME = 2;
+    static constexpr uint8_t DESCRIPTION = 3;
+    static constexpr uint8_t HASHTAGS = 4;
+    static constexpr uint8_t REQUESTED_BY = 5;
+    static constexpr uint8_t REQUESTED_BY_PHRASE = 6;
+    static constexpr uint8_t PROMOTE_SHARE = 7;
+    static constexpr uint8_t LINK_BIO = 8;
+    static constexpr uint8_t IS_VIDEO = 9;
+    static constexpr uint8_t HEADER = 10;
+    static constexpr uint8_t USER = 11;
+  }
 
 class IGTaskHandler {
  public:
@@ -18,7 +38,18 @@ class IGTaskHandler {
       return Scheduler::Task{};
     }
 
-    auto file_info = argv.at(0);
+    auto mask = argv.at(IGTaskIndex::MASK);
+    auto file_info = argv.at(IGTaskIndex::FILEINFO);
+    auto datetime = argv.at(IGTaskIndex::DATETIME);
+    auto description = argv.at(IGTaskIndex::DESCRIPTION);
+    auto hashtags = argv.at(IGTaskIndex::HASHTAGS);
+    auto requested_by = argv.at(IGTaskIndex::REQUESTED_BY);
+    auto requested_by_phrase = argv.at(IGTaskIndex::REQUESTED_BY_PHRASE);
+    auto promote_share = argv.at(IGTaskIndex::PROMOTE_SHARE);
+    auto link_bio = argv.at(IGTaskIndex::LINK_BIO);
+    auto is_video = argv.at(IGTaskIndex::IS_VIDEO) == "1";
+    auto header = argv.at(IGTaskIndex::HEADER);
+    auto user = argv.at(IGTaskIndex::USER);
 
     std::vector<FileInfo> task_files = FileUtils::parseFileInfo(file_info);
 
@@ -28,18 +59,6 @@ class IGTaskHandler {
       task_files.at(i).first =
           media_filename + "/data/" + uuid + "/" + task_files.at(i).first;
     }
-    // notify KServer of filename received
-    auto datetime = argv.at(1);
-    auto description = argv.at(2);
-    auto hashtags = argv.at(3);
-    auto requested_by = argv.at(4);
-    auto requested_by_phrase = argv.at(5);
-    auto promote_share = argv.at(6);
-    auto link_bio = argv.at(7);
-    auto is_video = argv.at(8) == "1";
-    auto mask = argv.at(9);
-    auto header = argv.at(10);
-    auto user = argv.at(11);
 
     std::string env_file_string{"#!/usr/bin/env bash\n"};
     env_file_string += "HEADER='" + header + "'\n";

--- a/include/executor/task_handlers/task.hpp
+++ b/include/executor/task_handlers/task.hpp
@@ -1,0 +1,10 @@
+#ifndef __TASK_HPP__
+#define __TASK_HPP__
+
+namespace Task {
+  namespace TaskIndexes {
+    static constexpr uint8_t MASK = 0;
+  }
+}
+
+#endif // __TASK_HPP__

--- a/include/request/request_handler.hpp
+++ b/include/request/request_handler.hpp
@@ -17,7 +17,8 @@
 #include <iostream>
 #include <map>
 #include <mutex>
-#include <request/task_handlers/instagram.hpp>
+#include <executor/task_handlers/task.hpp>
+#include <executor/task_handlers/instagram.hpp>
 #include <server/types.hpp>
 #include <string>
 #include <system/cron.hpp>
@@ -329,8 +330,7 @@ class RequestHandler {
             "arguments");
         return "";
       }
-      // TODO: mask should be the first element
-      auto mask = argv.at(argv.size() - 3);
+      auto mask = argv.at(Task::TaskIndexes::MASK);
       auto kdb = Database::KDB();
 
       QueryValues result =

--- a/include/request/request_handler.hpp
+++ b/include/request/request_handler.hpp
@@ -329,6 +329,7 @@ class RequestHandler {
             "arguments");
         return "";
       }
+      // TODO: mask should be the first element
       auto mask = argv.at(argv.size() - 3);
       auto kdb = Database::KDB();
 


### PR DESCRIPTION
A lot depends on the fact that a task is associated with an application which KServer knows about.

Change argument order to place "mask" at the front.
Make unloading task arguments cleaner