### PR TITLE
fixing compiler warnings

### DIFF
--- a/include/codec/util.hpp
+++ b/include/codec/util.hpp
@@ -479,7 +479,7 @@ std::vector<FileInfo> parseFileInfo(std::string file_info) {
     auto timestamp = file_info.substr(index, 10);
     pipe_pos = findIndexAfter(file_info, index, '|');
     auto file_name = file_info.substr(index + 10, (pipe_pos - index - 10));
-    delim_pos = findIndexAfter(file_info, index, '::');
+    delim_pos = findIndexAfter(file_info, index, ':');
     auto type =
         file_info.substr(index + 10 + file_name.size() + 1,
                          (delim_pos - index - 10 - file_name.size() - 1));

--- a/include/database/kdb.hpp
+++ b/include/database/kdb.hpp
@@ -172,6 +172,7 @@ class KDB {
     } catch (const std::exception &e) {
       KLOG->error("Error", e.what());
     }
+    return "";
   }
 
  private:

--- a/include/request/request_handler.hpp
+++ b/include/request/request_handler.hpp
@@ -366,6 +366,7 @@ class RequestHandler {
       }
       return std::string{"Operation failed"};
     }
+    return "";
   }
 
   /**
@@ -546,12 +547,12 @@ class RequestHandler {
         if (task_it != it->second.end()) {
           if (error) {
             // Send email to the administrator
-            KLOG->info("Sending email to administrator about failed task");
             SystemUtils::sendMail(ConfigParser::Admin::email(), std::string{Scheduler::Messages::TASK_ERROR_EMAIL + value});
             auto status = task_it->completed == Scheduler::Completed::FAILED ?
             Scheduler::Completed::RETRY_FAIL : Scheduler::Completed::FAILED;
             task_it->completed = status;
             m_scheduler->updateStatus(&*task_it);
+            KLOG->info("Sending email to administrator about failed task.\nNew Status: {}", Scheduler::Completed::STRINGS[status]);
           }
           KLOG->info(
               "RequestHandler::onProcessComplete() - removing completed "

--- a/include/system/cron.hpp
+++ b/include/system/cron.hpp
@@ -88,6 +88,7 @@ class Cron : public CronInterface<Job> {
                          std::to_string(job.month) + " * " + job.path +
                          "\") | sort - | uniq - | crontab -"};
     }
+    return "";
   }
 
   virtual void addJob(Job job) {


### PR DESCRIPTION
BREAKING CHANGE: RequestHandler parses file info and expects ":" as a delimiter (previously "::")