### PR TITLE
Process Executor: Forked processes with timeouts

### DIFF
--- a/include/codec/crypter.hpp
+++ b/include/codec/crypter.hpp
@@ -1,7 +1,0 @@
-#ifndef __CRYPTER__HPP__
-#define __CRYPTER_HPP__
-
-class Crypter {};
-
-#endif  // __CRYPTER_HPP__
-

--- a/include/executor/executor.hpp
+++ b/include/executor/executor.hpp
@@ -44,8 +44,9 @@ const char *findWorkDir(std::string_view path) {
 /** Impl */
 ProcessResult run_(std::string_view path, std::vector<std::string> argv) {
   std::vector<std::string> v_args{};
+  v_args.reserve(argv.size() + 1);
   v_args.push_back(std::string(path));
-  for (const auto &arg : argv) {
+  for (auto&& arg : argv) {
     v_args.push_back(arg);
   }
 
@@ -156,6 +157,7 @@ class ProcessExecutor : public ProcessManager {
         notifyTrackedProcessEvent(result.output, mask, id, client_socket_fd,
                                   result.error);
         if (!result.error && type == ExecutionRequestType::SCHEDULED) {
+          // TODO: Get rid of this? Handle in request_handler
           Database::KDB kdb{};
           auto SUCCESS =
               Scheduler::Completed::STRINGS[Scheduler::Completed::SUCCESS];

--- a/include/executor/execxx.hpp
+++ b/include/executor/execxx.hpp
@@ -33,54 +33,89 @@ std::string readFd(int fd) {
 
 ProcessResult qx(std::vector<std::string> args,
                const std::string& working_directory = "") {
-  int stdout_fds[2];
+  int stdout_fds[2], stderr_fds[2];
   pipe(stdout_fds);
-
-  int stderr_fds[2];
   pipe(stderr_fds);
 
   const pid_t pid = fork();
-  if (!pid) {
+
+  if (!pid) { // Child process
+
     if (!working_directory.empty()) {
       chdir(working_directory.c_str());
     }
+
     close(stdout_fds[0]);
-    dup2(stdout_fds[1], 1);
+    dup2 (stdout_fds[1], 1);
     close(stdout_fds[1]);
     close(stderr_fds[0]);
-    dup2(stderr_fds[1], 2);
+    dup2 (stderr_fds[1], 2);
     close(stderr_fds[1]);
 
-    std::vector<char*> vc(args.size() + 1, 0);
-    for (size_t i = 0; i < args.size(); ++i) {
-      vc[i] = const_cast<char*>(args[i].c_str());
-    }
+    std::vector<char*> process_arguments{};
+    process_arguments.reserve(args.size() + 1);
 
-    execvp(vc[0], &vc[0]);
-    exit(0);
+    for (size_t i = 0; i < args.size(); ++i) {
+      process_arguments[i] = const_cast<char*>(args[i].c_str());
+    }
+    // Execute
+    execvp(process_arguments[0], &process_arguments[0]);
+    exit(0); // Exit with no error
   }
   close(stdout_fds[1]);
 
-  ProcessResult result{};
+  ProcessResult result{};                         // To gather result
 
-  std::string stdout_string = readFd(stdout_fds[0]);
-  if (stdout_string.size() <= 1) { // an empty stdout might be a single whitespace
-    // TODO: Find out what's missing from the output (thrown exception messages aren't included)
-    std::string stderr_string = readFd(stderr_fds[0]);
-    result.output = stderr_string;
-    result.error = true;
-  } else {
-    result.output = stdout_string;
+  fd_set read_file_descriptors{};                 // Mask for file descriptors
+
+  timeval time_value{                             // 30 second timeout
+    .tv_sec = 30,
+    .tv_usec = 0
+  };
+
+  int retval;
+  int max_fd_range = stdout_fds[0] > stderr_fds[0] ?
+    (stdout_fds[0]) + 1 :
+    (stderr_fds[0]) + 1;
+
+  FD_ZERO(&read_file_descriptors);                 // clear
+  FD_SET(stdout_fds[0], &read_file_descriptors);   // add stdout to mask
+  FD_SET(stderr_fds[0], &read_file_descriptors);   // add stderr to mask
+
+  for (;;) {
+    // select() call determines if there are file descriptors to read from
+    int num_of_fd_outputs = select(
+      max_fd_range,                                // max range of file descriptor to listen for
+      &read_file_descriptors,                      // read fd mask
+      NULL,                                        // write fd mask
+      NULL,                                        // error fd mask
+      &time_value
+    );
+
+    if (num_of_fd_outputs > 0) {                   // output can be read
+      if (FD_ISSET(stdout_fds[0], &read_file_descriptors)) {
+        result.output = readFd(stdout_fds[0]);
+        if (result.output.empty()) {               // stdout had empty output
+          result.output = "Unknown error. Nothing returned from process.";
+          result.error = true;
+        }
+      }
+      if (FD_ISSET(stderr_fds[0], &read_file_descriptors)) { // stderr has output
+        printf("ProcessExecutor's forked process returned an error");
+        result.output = readFd(stderr_fds[0]);
+        result.error = true;
+      }
+      break;
+    } else {
+      printf("ProcessExecutor's forked process timed out");
+      result.output = "Timeout";
+      result.error = true;
+    }
   }
 
   close(stdout_fds[0]);
   close(stderr_fds[0]);
   close(stderr_fds[1]);
-
-  int r, status;
-  do {
-    r = waitpid(pid, &status, 0);
-  } while (r == -1 && errno == EINTR);
 
   return result;
 }

--- a/include/executor/execxx.hpp
+++ b/include/executor/execxx.hpp
@@ -110,6 +110,7 @@ ProcessResult qx(std::vector<std::string> args,
       printf("ProcessExecutor's forked process timed out");
       result.output = "Timeout";
       result.error = true;
+      break;
     }
   }
 

--- a/include/executor/scheduler.hpp
+++ b/include/executor/scheduler.hpp
@@ -290,7 +290,7 @@ class Scheduler : public DeferInterface, CalendarManagerInterface {
    * @return [out] {std::vector<Task>} A vector of Task objects
    */
   std::vector<Task> fetchRecurringTasks() {
-    using SelectJoinFilters = std::vector<std::variant<CompFilter, CompBetweenFilter>>;
+    using SelectJoinFilters = std::vector<std::variant<CompFilter, CompBetweenFilter, MultiOptionFilter>>;
     return parseTasks(
       m_kdb.selectJoin<SelectJoinFilters>(
         "schedule", {                                                     // table
@@ -313,6 +313,13 @@ class Scheduler : public DeferInterface, CalendarManagerInterface {
             std::to_string(TimeUtils::unixtime()),                        // field
             "(recurring.time + (SELECT get_recurring_seconds(schedule.recurring) - 900))",  // value (from function)
             ">"                                                           // comparator
+          },
+          MultiOptionFilter{                            // filter
+            "completed",                                // field of comparison
+            "IN", {                                     // comparison type
+              Completed::STRINGS[Completed::SCHEDULED], // set of values for comparison
+              Completed::STRINGS[Completed::FAILED]
+            }
           }
         },
         Join{

--- a/src/database_connection.cpp
+++ b/src/database_connection.cpp
@@ -261,7 +261,7 @@ std::string selectStatement(T query) {
           query.filter);
       return std::string{"SELECT " + fieldsAsString(query.fields) + " FROM " +
                          query.table + " " + filter_string};
-    } else if constexpr (std::is_same_v<T, JoinQuery<std::vector<std::variant<CompFilter, CompBetweenFilter>>>>) {
+    } else if constexpr (std::is_same_v<T, JoinQuery<std::vector<std::variant<CompFilter, CompBetweenFilter, MultiOptionFilter>>>>) {
       filter_string += getVariantFilterStatement(query.filter);
       std::string join_string = getJoinStatement(query.join);
       return std::string{"SELECT " + fieldsAsString(query.fields) + " FROM " + query.table + " " + join_string + " " + filter_string};
@@ -395,6 +395,10 @@ template QueryResult DatabaseConnection::query(
 
 template QueryResult DatabaseConnection::query(
   JoinQuery<std::vector<std::variant<CompFilter, CompBetweenFilter>>>
+);
+
+template QueryResult DatabaseConnection::query(
+  JoinQuery<std::vector<std::variant<CompFilter, CompBetweenFilter, MultiOptionFilter>>>
 );
 
 std::string DatabaseConnection::query(InsertReturnQuery query) {


### PR DESCRIPTION
## Description

Forked processes had their stdout/stderr file descriptors' output waited upon via `waitpid()`. 
This PR switches to a `select()` based implementation with a 30 second timeout.

