### PR TITLE
Client address fix

### DIFF
--- a/include/system/process/ipc/manager.cpp
+++ b/include/system/process/ipc/manager.cpp
@@ -249,10 +249,11 @@ std::stoi(args.at(constants::PLATFORM_PAYLOAD_CMD_INDEX)),
         }
 
         botbroker_handler* value = static_cast<botbroker_handler*>(dead_it->second);
+        const auto addr = value->get_addr();
         delete value;
 
         auto it = m_clients.insert_or_assign(peer,
-          new botbroker_handler{config::Process::broker_address(), m_context, peer, this, true});
+          new botbroker_handler{addr, m_context, peer, this, true});
 
         if (it.second)
         {

--- a/include/system/process/ipc/manager.cpp
+++ b/include/system/process/ipc/manager.cpp
@@ -263,7 +263,7 @@ std::stoi(args.at(constants::PLATFORM_PAYLOAD_CMD_INDEX)),
         else
           klog().e("Failed to replace IPC worker for {}", peer);
       });
-    if (! m_daemon.validate(peer))
+    if (!m_daemon.validate(peer))
       klog().t("Couldn't validate heartbeat for {}", peer);
   }
   //*******************************************************************//

--- a/include/system/process/ipc/manager.cpp
+++ b/include/system/process/ipc/manager.cpp
@@ -241,9 +241,28 @@ std::stoi(args.at(constants::PLATFORM_PAYLOAD_CMD_INDEX)),
       m_daemon.add_observer(peer, [&]
       {
         klog().e("Heartbeat timed out for {}", peer);
-        m_clients.at(peer)->send_ipc_message(std::make_unique<status_check>());
+        auto dead_it = m_clients.find(peer);
+        if (dead_it == m_clients.end())
+        {
+          klog().w("IPC manager does not have an IPC worker for {}", peer);
+          return;
+        }
+
+        botbroker_handler* value = static_cast<botbroker_handler*>(dead_it->second);
+        delete value;
+
+        auto it = m_clients.insert_or_assign(peer,
+          new botbroker_handler{config::Process::broker_address(), m_context, peer, this, true});
+
+        if (it.second)
+        {
+          it.first->second->send_ipc_message(std::make_unique<status_check>());
+          klog().d("Replaced IPC worker for {}", peer);
+        }
+        else
+          klog().e("Failed to replace IPC worker for {}", peer);
       });
-    if (!m_daemon.validate(peer))
+    if (! m_daemon.validate(peer))
       klog().t("Couldn't validate heartbeat for {}", peer);
   }
   //*******************************************************************//


### PR DESCRIPTION
When client HB times out and we replace the client object, we need to get the proper address from the old client rather than relying on the config (which itself should be replaced with a class, instead of a collection of functions)