### PR TITLE
KServer::run

### DIFF
--- a/include/request/controller.hpp
+++ b/include/request/controller.hpp
@@ -46,7 +46,7 @@ class Controller
  using ClientValidateFn  = std::function<void(void)>;
 
  public:
-  Controller();
+  Controller(int* control_sock);
   Controller(Controller&& r);
   Controller(const Controller& r);
   Controller &operator=(const Controller& handler);
@@ -109,5 +109,8 @@ class Controller
   uint32_t                          m_client_rq_count;
   uint32_t                          m_system_rq_count;
   uint32_t                          m_err_count;
+
+  int*                              m_control_sock;
+  bool                              m_shutdown{false};
 };
 }  // ns kiq

--- a/include/server/kserver.hpp
+++ b/include/server/kserver.hpp
@@ -98,15 +98,16 @@ public:
   KServer(int argc, char **argv);
   ~KServer();
 
-  void            Broadcast                (const std::string& event, const std::vector<std::string>& argv);
-  void            SendEvent                (const int32_t& client_fd, const std::string& event,
-                                            const std::vector<std::string>& argv);
-  void            SendFile                 (const int32_t& client_fd, const std::string& filename);
-  void            EraseMessageHandler      (const int32_t& client_fd);
-  void            EraseFileHandler         (const int32_t& client_fd);
-  Controller&     GetController            ();
-  IPCManager&     GetIPCMgr                ();
-  FileManager&    GetFileMgr               ();
+  void            Broadcast          (const std::string& event, const std::vector<std::string>& argv);
+  void            SendEvent          (const int32_t& client_fd, const std::string& event,
+                                      const std::vector<std::string>& argv);
+  void            SendFile           (const int32_t& client_fd, const std::string& filename);
+  void            EraseMessageHandler(const int32_t& client_fd);
+  void            EraseFileHandler   (const int32_t& client_fd);
+  Controller&     GetController      ();
+  IPCManager&     GetIPCMgr          ();
+  FileManager&    GetFileMgr         ();
+  void            run                ();
 
 private:
   using FileHandlers = std::unordered_map<int32_t, kiqoder::FileHandler>;
@@ -159,6 +160,7 @@ private:
   bool                      m_message_pending;
   int32_t                   m_message_pending_fd;
   uint32_t                  m_errors{0};
+  int                       m_control_sock{0};
 };
 
 };     // namespace kiq


### PR DESCRIPTION
KServer now has a run method of its own (in addition to that of its base class, SocketListener)

KServer now essentially has the ability to shut down if the controller deems it necessary

This was done so KServer can nudge the IPC Manager to refresh its public-facing socket if things get stale